### PR TITLE
Implement optional chaining for safer products mapping in HomeScreen

### DIFF
--- a/frontend/src/screens/HomeScreen.js
+++ b/frontend/src/screens/HomeScreen.js
@@ -55,7 +55,7 @@ function HomeScreen() {
           <MessageBox variant="danger">{error}</MessageBox>
         ) : (
           <Row>
-            {products.map((product) => (
+            {products?.map((product) => (
               <Col key={product.slug} sm={6} md={4} lg={3} className="mb-3">
                 <Product product={product}></Product>
               </Col>


### PR DESCRIPTION
Fixed Issue : #26 

This pull request improves the HomeScreen component by incorporating optional chaining in the mapping of the products array.

By using optional chaining, we ensure that if the products array is undefined or null, the application will not throw a runtime error when invoking .map(). Instead, it will safely return undefined.

This enhancement improves the stability of the component, allowing it to handle scenarios where data may not yet be available without causing crashes.





